### PR TITLE
fix: Call imageEditorInst.destroy() on unmount

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -19,11 +19,12 @@ export default class ImageEditor extends React.Component {
   }
 
   componentWillUnmount() {
+    this.unbindEventHandlers();
+
     this.imageEditorInst.destroy();
   }
 
   shouldComponentUpdate(nextProps) {
-    console.log('nextProps');
     this.bindEventHandlers(this.props, nextProps);
 
     return false;
@@ -44,10 +45,18 @@ export default class ImageEditor extends React.Component {
         const eventName = key[2].toLowerCase() + key.slice(3);
         // For <ImageEditor onFocus={condition ? onFocus1 : onFocus2} />
         if (prevProps && prevProps[key] !== props[key]) {
-          console.log('ho?');
           this.imageEditorInst.off(eventName);
         }
         this.imageEditorInst.on(eventName, props[key]);
+      });
+  }
+
+  unbindEventHandlers() {
+    Object.keys(this.props)
+      .filter((key) => /on[A-Z][a-zA-Z]+/.test(key))
+      .forEach((key) => {
+        const eventName = key[2].toLowerCase() + key.slice(3);
+        this.imageEditorInst.off(eventName);
       });
   }
 

--- a/src/index.js
+++ b/src/index.js
@@ -22,6 +22,8 @@ export default class ImageEditor extends React.Component {
     this.unbindEventHandlers();
 
     this.imageEditorInst.destroy();
+
+    this.imageEditorInst = null;
   }
 
   shouldComponentUpdate(nextProps) {
@@ -40,7 +42,7 @@ export default class ImageEditor extends React.Component {
 
   bindEventHandlers(props, prevProps) {
     Object.keys(props)
-      .filter((key) => /on[A-Z][a-zA-Z]+/.test(key))
+      .filter(this.isEventHandlerKeys)
       .forEach((key) => {
         const eventName = key[2].toLowerCase() + key.slice(3);
         // For <ImageEditor onFocus={condition ? onFocus1 : onFocus2} />
@@ -53,11 +55,15 @@ export default class ImageEditor extends React.Component {
 
   unbindEventHandlers() {
     Object.keys(this.props)
-      .filter((key) => /on[A-Z][a-zA-Z]+/.test(key))
+      .filter(this.isEventHandlerKeys)
       .forEach((key) => {
         const eventName = key[2].toLowerCase() + key.slice(3);
         this.imageEditorInst.off(eventName);
       });
+  }
+
+  isEventHandlerKeys(key) {
+    return /on[A-Z][a-zA-Z]+/.test(key);
   }
 
   render() {

--- a/src/index.js
+++ b/src/index.js
@@ -18,6 +18,10 @@ export default class ImageEditor extends React.Component {
     this.bindEventHandlers(this.props);
   }
 
+  componentWillUnmount() {
+    this.imageEditorInst.destroy();
+  }
+
   shouldComponentUpdate(nextProps) {
     console.log('nextProps');
     this.bindEventHandlers(this.props, nextProps);


### PR DESCRIPTION
<!-- EDIT TITLE PLEASE -->
<!-- It should be one of them
  <ISSUE TYPE>: Short Description (<CLOSING TYPE> #<ISSUE NUMBERS>)
  ex)
  feat: add new feature (close #111)
  fix: wrong behavior (fix #111)
  chore: change build tool (ref #111)
-->

<!-- SPECIFY A ISSUE TYPE AT HEAD
  feat: A new feature
  fix: A bug fix
  docs: Documentation only changes
  style: Changes that do not affect the meaning of the code (white-space, formatting etc)
  refactor: A code change that neither fixes a bug or adds a feature
  perf: A code change that improves performance
  test: Adding missing tests
  chore: Changes to the build process or auxiliary tools and libraries such as documentation generation
-->

<!-- ADD CLOSING TYPE AND ISSUE NUMBER AT TAIL
  (<CLOSING TYPE> #<ISSUE NUMBERS>)
  close: resolve not a bug(feature, docs, etc) completely
  fix: resolve a bug completely
  ref: not fully resolved or related to
-->

### Please check if the PR fulfills these requirements
- [x] It's the right issue type on the title
- [x] When resolving a specific issue, it's referenced in the PR's title (e.g. `fix #xxx[,#xxx]`, where "xxx" is the issue number)
- [x] The commit message follows our guidelines
- [ ] Tests for the changes have been added (for bug fixes/features)
- [ ] Docs have been added/updated (for bug fixes/features)
- [x] It does not introduce a breaking change or has a description of the breaking change

### Description

- Unbind all events before destroy that passed via props.
- Call `destroy()` in the `ComponentWillUnmount` hook.

---
Thank you for your contribution to TOAST UI product. 🎉 😘 ✨
